### PR TITLE
fix: support cargo v4

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -127917,9 +127917,9 @@ class CacheConfig {
                 try {
                     const content = await promises_default().readFile(cargo_lock, { encoding: "utf8" });
                     const parsed = parse(content);
-                    if (parsed.version !== 3 || !("package" in parsed)) {
+                    if (parsed.version !== 3 || parsed.version !== 4 || !("package" in parsed)) {
                         // Fallback to caching them as regular file since this action
-                        // can only handle Cargo.lock format version 3
+                        // can only handle Cargo.lock format version 3 or 4
                         lib_core.warning('Unsupported Cargo.lock format, fallback to caching entire file');
                         keyFiles.push(cargo_lock);
                         continue;

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -127917,9 +127917,9 @@ class CacheConfig {
                 try {
                     const content = await promises_default().readFile(cargo_lock, { encoding: "utf8" });
                     const parsed = parse(content);
-                    if (parsed.version !== 3 || !("package" in parsed)) {
+                    if (parsed.version !== 3 || parsed.version !== 4 || !("package" in parsed)) {
                         // Fallback to caching them as regular file since this action
-                        // can only handle Cargo.lock format version 3
+                        // can only handle Cargo.lock format version 3 or 4
                         core.warning('Unsupported Cargo.lock format, fallback to caching entire file');
                         keyFiles.push(cargo_lock);
                         continue;

--- a/src/config.ts
+++ b/src/config.ts
@@ -197,9 +197,9 @@ export class CacheConfig {
           const content = await fs_promises.readFile(cargo_lock, { encoding: "utf8" });
           const parsed = toml.parse(content);
 
-          if (parsed.version !== 3 || !("package" in parsed)) {
+          if (parsed.version !== 3 || parsed.version !== 4 || !("package" in parsed)) {
             // Fallback to caching them as regular file since this action
-            // can only handle Cargo.lock format version 3
+            // can only handle Cargo.lock format version 3 or 4
             core.warning('Unsupported Cargo.lock format, fallback to caching entire file');
             keyFiles.push(cargo_lock);
             continue;


### PR DESCRIPTION
This PR solves the issue of Cargo lock v4 not being cached properly. See for example the warning in 
https://github.com/near/mpc/actions/runs/17207188340/job/48810277116?pr=920:
```
Run WarpBuilds/rust-cache@v2
Warning: Unsupported Cargo.lock format, fallback to caching entire file
```

For context of the same fix upstream see https://github.com/Swatinem/rust-cache/issues/209